### PR TITLE
Fix host index selection bug in rpadmin

### DIFF
--- a/rpadmin/admin.go
+++ b/rpadmin/admin.go
@@ -124,7 +124,7 @@ func NewHostClient(addrs []string, tls *tls.Config, auth Auth, forCloud bool, ho
 		if i < 0 || i >= len(addrs) {
 			return nil, fmt.Errorf("admin host %d is out of allowed range [0, %d)", i, len(addrs))
 		}
-		addrs = []string{addrs[0]}
+		addrs = []string{addrs[i]}
 	} else {
 		addrs = []string{host} // trust input is hostname (validate below)
 	}

--- a/rpadmin/admin_test.go
+++ b/rpadmin/admin_test.go
@@ -484,3 +484,13 @@ func (w *wrappedConnection) Close() error {
 	w.closed = true
 	return w.Conn.Close()
 }
+
+func TestNewHostClientIndex(t *testing.T) {
+	addrs := []string{"http://host0:9644", "http://host1:9644"}
+
+	cl, err := NewHostClient(addrs, nil, new(NopAuth), false, "1")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(cl.urls))
+	assert.Equal(t, "http://host1:9644", cl.urls[0])
+}


### PR DESCRIPTION
## Summary
- fix `NewHostClient` to use the requested address index
- add test verifying index handling

## Testing
- `go test ./...`
